### PR TITLE
Create Privacy Policy

### DIFF
--- a/Privacy Policy
+++ b/Privacy Policy
@@ -1,0 +1,74 @@
+#SteemMakers Privacy Policy:
+
+SteemMakers wants you to understand how and why we collect, use, and share information about you when you access and use SteemMakers platform, or when you otherwise interact with us.
+
+By accessing or using the Platform, you consent to the information collection, disclosure and use practices described in this Privacy Policy.
+Please note that certain features or services referenced in this Privacy Policy may not be offered on the platform at all times.
+
+##INFORMATION WE COLLECT AUTOMATICALLY:
+
+When you access or use our Services, we may also automatically collect information about you.
+
+This includes:
+
+###LOG AND USAGE DATA:
+
+We may log information when you access and use the Services. This may include your IP address, user-agent string, operating system, referral URLs, device information (e.g., device IDs), pages visited, links clicked, user interactions, the requested URL, hardware settings, and search terms.
+
+###INFORMATION FROM COOKIES:
+
+We may receive information from cookies, which are pieces of data the platform stores and sends back to us when we make requests.
+We use this information to improve your experience, understand user activity, and improve the quality of our Services.
+For example, we store and retrieve information about your preferred settings.
+
+##WE USE INFORMATION WE COLLECT:
+
+To provide and improve the SteemMakers Platform, address your inquiries and verify the information you provide.
+
+Prevent and investigate potentially prohibited or illegal activities, and/or violations of our posted user terms;
+
+To contact you with administrative communications, marketing or promotional materials (on behalf of SteemMakers) and other information that may be of interest to you.
+
+Compare information for accuracy and verify it with third parties (e.g. Steemit.com, SteemConnect.com, etc.).
+
+For the purposes disclosed at the time you provide your information, with your consent, and as further described in this Privacy Policy.
+
+We will not use your personal information for purposes other than those purposes we have disclosed to you, without your permission.
+From time to time we may request your permission to allow us to share your personal information with third parties.
+You may opt out of having your personal information shared with third parties, or from allowing us to use your personal information for any purpose that is incompatible with the purposes for which we originally collected it or subsequently obtained your authorization.
+If you choose to so limit the use of your personal information, certain features or SteemMakers platform may not be available to you.
+
+##HOW WE SHARE INFORMATION WITH OTHER PARTIES:
+
+We may share your personal information with:
+
+Service providers under contract who help with parts of our business operations such as fraud prevention, bill collection, marketing, and technology services. 
+Our contracts dictate that these service providers only use your information in connection with the services they perform for us and not for their own benefit.
+
+Companies or other entities that we plan to merge with or be acquired by. Should such a merger occur, we will require that the new merged entity follow this Privacy Policy with respect to your personal information. You will receive prior notice of any merger.
+
+Other third parties with your consent or direction to do so.
+
+SteemMakers will not sell or rent any of your personal information to third parties, but will only share your personal information with third parties as described in this policy.
+
+##AGE LIMIT:
+
+SteemMakers is intended and directed at individuals of all ages.
+
+##COMMUNITY FORUMS/FEEDBACK:
+
+We collect feedbacks from SteemMakers Platform users about their experiences with other SteemMakers users as well as on the Platform.
+
+Please note that you can provide any feedback via the Discord Jef Patat#8728. 
+
+You may choose, to submit or post questions, comments, or other content (collectively, “User Forum Content”). On very rare occasions, we may remove feedback pursuant to the relevant provisions of our Terms of Service, including the Terms of Use.
+
+##CHANGES TO THIS PRIVACY POLICY:
+
+We may change this Privacy Policy from time to time. If we do, we will let you know by revising the date at the top of the policy. If we make a change to this policy that, in our sole discretion, is material, we will provide you with additional notice. 
+We encourage you to review the Privacy Policy whenever you access or use our Service or otherwise interact with us to stay informed about our information practices and the ways you can help protect your privacy.
+If you continue to use our platform after Privacy Policy changes go into effect, you consent to the revised policy.
+
+Contact -
+Questions or comments about SteemMakers may be directed to Jef Patat#8728 on discord.
+Github: https://github.com/JefPatat/SteemMakers


### PR DESCRIPTION
This Policy is intended to safeguard the SteemMakers Platform against the dangers of being sued by any aggrieved members of the platform. Thus, it is essential that all members read it before going ahead with the use of this platform and all services herein embedded in it.